### PR TITLE
Added "spawn" as an alias for /pw teleport currentWorldName Issue #26

### DIFF
--- a/src/main/java/me/lokka30/phantomworlds/commands/phantomworlds/PhantomWorldsCommand.java
+++ b/src/main/java/me/lokka30/phantomworlds/commands/phantomworlds/PhantomWorldsCommand.java
@@ -62,6 +62,7 @@ public class PhantomWorldsCommand implements TabExecutor {
                     break;
                 case "teleport":
                 case "tp":
+                case "spawn":
                     teleportSubcommand.parseCommand(main, sender, cmd, label, args);
                     break;
                 case "list":
@@ -121,7 +122,7 @@ public class PhantomWorldsCommand implements TabExecutor {
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command cmd, @NotNull String label, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("create", "info", "list", "setspawn", "reload", "teleport", "unload", "debug", "compatibility");
+            return Arrays.asList("create", "info", "list", "setspawn", "reload", "teleport", "spawn", "unload", "debug", "compatibility");
         }
 
         switch (args[0].toLowerCase(Locale.ROOT)) {
@@ -136,6 +137,7 @@ public class PhantomWorldsCommand implements TabExecutor {
             case "reload":
                 return reloadSubcommand.parseTabCompletion(main, sender, cmd, label, args);
             case "teleport":
+            case "spawn":
                 return teleportSubcommand.parseTabCompletion(main, sender, cmd, label, args);
             case "unload":
                 return unloadSubcommand.parseTabCompletion(main, sender, cmd, label, args);

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -21,6 +21,7 @@ command:
       - '&8 &m->&b /%label% create &8- &7create/import a world'
       - '&8 &m->&b /%label% list &8- &7list loaded worlds'
       - '&8 &m->&b /%label% teleport &8- &7teleport to a loaded world''s spawnpoint'
+      - '&8 &m->&b /%label% spawn &8- &7teleport to the spawn of the current world'
       - '&8 &m->&b /%label% setspawn &8- &7set the spawnpoint of a world'
       - '&8 &m->&b /%label% unload &8- &7unload a loaded world'
       - '&8 &m->&b /%label% reload &8- &7reload all config & data files'
@@ -164,6 +165,17 @@ command:
 
         usage-console:
           - '%prefix% Invalid usage for console, try ''&b/%label% teleport <world> <player>&7''.'
+
+        success:
+          - '%prefix% Teleported player ''&b%player%&7'' to the spawn point of world ''&b%world%&7''.'
+          
+      spawn:
+
+        usage:
+          - '%prefix% Invalid usage, try ''&b/%label% spawn [player]&7''.'
+
+        usage-console:
+          - '%prefix% Invalid usage for console, try ''&b/%label% spawn <player>&7''.'
 
         success:
           - '%prefix% Teleported player ''&b%player%&7'' to the spawn point of world ''&b%world%&7''.'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -44,6 +44,7 @@ permissions:
       phantomworlds.command.phantomworlds.list: true
       phantomworlds.command.phantomworlds.setspawn: true
       phantomworlds.command.phantomworlds.teleport: true
+      phantomworlds.command.phantomworlds.spawn: true
       phantomworlds.command.phantomworlds.unload: true
       phantomworlds.command.phantomworlds.reload: true
 
@@ -78,6 +79,10 @@ permissions:
   phantomworlds.command.phantomworlds.teleport:
     default: op
     description: 'Ability to run /pw teleport'
+    
+    phantomworlds.command.phantomworlds.spawn:
+    default: op
+    description: 'Ability to run /pw spawn'
 
   phantomworlds.command.phantomworlds.unload:
     default: op


### PR DESCRIPTION
PhantomWorldsCommand.java:
- Added "spawn" as a valid command in onCommand() and onTabComplete().

TeleportSubcommand.java:
- parseCommand():
Added String that holds the current subCommand to use in MultiMessages. Also added check to see if the subCommand is "tp" and setting it equal to "teleport" if true because the MultiMessages would not work with "tp". Updated the check for valid number of arguments to include "spawn". Moved the checks for if the world is null and if the target Player is the sender into teleportToWorld(). Added switch to check if the command is "teleport" or "spawn" and then calling teleportToWorld() with the correct arguments for each case.

- parseTabComplete():
Also added String for the current subCommand here. Added switch to check if the command is "teleport" or "spawn" and then check the number of arguments for tab completion.

- teleportToWorld():
Everything is the same here as it was when it was in parseCommand() excpet it now uses targetPlayer instead of args[2] and world instead of args[1].  The String subCommand is being used in some MultiMessages here too.

messages.yml & plugin.yml:
- Added "spawn" as a command in both of these files. Wasn't exactly sure what to do here, but I just based it on the teleport command since they are essentially the same. 

Let me know about any problems and I'll fix them. Thanks.